### PR TITLE
Add image width to style

### DIFF
--- a/code/ImageOptionsetField.php
+++ b/code/ImageOptionsetField.php
@@ -70,7 +70,8 @@ class ImageOptionsetField extends OptionsetField
         if (isset($this->imageIndex[$key])) {
             $imagePath = $this->imageIndex[$key];
             return sprintf(
-                'width:auto;height:%spx;background:url(%s);background-size:cover;',
+                'width:%spx;height:%spx;background:url(%s);background-size:cover;',
+                $this->getImageWidth(),
                 $this->getImageHeight(),
                 $imagePath
             );


### PR DESCRIPTION
Without the image width specified, the boxes around the images were cutting off part of the image.